### PR TITLE
Updated glyph to handle positive y offset by expanding the bounding b…

### DIFF
--- a/Sources/sfsymbols/Glyph.swift
+++ b/Sources/sfsymbols/Glyph.swift
@@ -67,14 +67,22 @@ struct Glyph {
         
         var box = CGRect.zero
         CTFontGetBoundingRectsForGlyphs(font, .default, &glyph, &box, 1)
-        let paddedBox = CGRect(x: 0, y: 0, width: box.width + (2 * box.origin.x), height: box.height - (2 * box.origin.y))
+        let paddedBox: CGRect
+        let paddedBoxMultiplier: CGFloat = box.origin.y > 0 ? 2 : -2
+        paddedBox = CGRect(x: 0, y: 0, width: box.width + (2 * box.origin.x), height: box.height + (paddedBoxMultiplier * box.origin.y))
+        
         self.boundingBox = paddedBox
         self.originOffset = box.origin
         
-
         let path = CTFontCreatePathForGlyph(font, glyph, nil)
-        var transform = CGAffineTransform(translationX: 0, y: -(2 * originOffset.y))
-        let copy = path?.copy(using: &transform)
+        
+        let copy: CGPath?
+        if box.origin.y > 0 {
+          copy = path
+        } else {
+          var transform = CGAffineTransform(translationX: 0, y: -2 * originOffset.y)
+          copy = path?.copy(using: &transform)
+        }
         self.cgPath = copy ?? CGPath(rect: CGRect(origin: .zero, size: paddedBox.size), transform: nil)
         
         self.fullName = pieces[12]


### PR DESCRIPTION
…ox height by 2 instead of -2 and not transforming the y value of the CGPath. It seems odd that the y doesn't need to be transformed by 2 in this case but it seems to work. 

List of symbols with positive y values: 
minus
multiply
equal
lessthan
greaterthan
xmark
line.horizontal.3
line.horizontal.3.decrease
scribble
chevron.up
chevron.down
chevron.compact.up
chevron.compact.down
hand.point.left
hand.point.right
bolt.horizontal
bolt.horizontal.fill
info
bold
italic
view.2d
light.min
light.max
list.dash
phone.down
phone.down.fill
recordingtape
ellipsis
eyeglasses
control
projective
arrow.up.left
arrow.up.right
arrow.left.and.right