### PR TITLE
Added 'imageset' export format

### DIFF
--- a/Sources/SFSymbolsCore/Exporter.swift
+++ b/Sources/SFSymbolsCore/Exporter.swift
@@ -19,6 +19,7 @@ public enum ExportFormat: String, CaseIterable {
     case pdf = "pdf"
     case iconset = "iconset"
     case iconsetPDF = "iconset-pdf"
+    case imageset = "imageset"
     
     public var exporter: Exporter {
         switch self {
@@ -29,8 +30,9 @@ public enum ExportFormat: String, CaseIterable {
             case .macosObjC: return macOSObjCExporter()
             case .png: return PNGExporter()
             case .pdf: return PDFExporter()
-            case .iconset: return IconsetExporter()
+            case .iconset: return SetExporter(ext: "iconset")
             case .iconsetPDF: return PDFAssetCatalog()
+            case .imageset: return SetExporter(ext: "imageset")
         }
     }
 }

--- a/Sources/SFSymbolsCore/Exporters/SetExporter.swift
+++ b/Sources/SFSymbolsCore/Exporters/SetExporter.swift
@@ -1,5 +1,5 @@
 //
-//  IconsetExporter.swift
+//  SetExporter.swift
 //  
 //
 //  Created by Dave DeLong on 9/19/19.
@@ -7,9 +7,14 @@
 
 import Foundation
 
-public struct IconsetExporter: Exporter {
+public struct SetExporter: Exporter {
 
     private let png = PNGExporter()
+    private let ext: String
+    
+    public init(ext: String = "iconset") {
+        self.ext = ext
+    }
     
     public func exportGlyphs(in font: Font, using options: ExportOptions) throws {
         let assetFolder = options.outputFolder.appendingPathComponent("SFSymbols.xcassets")
@@ -34,7 +39,7 @@ public struct IconsetExporter: Exporter {
     }
     
     public func exportGlyph(_ glyph: Glyph, in font: Font, to folder: URL) throws {
-        let iconset = folder.appendingPathComponent("\(glyph.fullName).iconset")
+        let iconset = folder.appendingPathComponent("\(glyph.fullName).\(ext)")
         try FileManager.default.createDirectory(at: iconset, withIntermediateDirectories: true, attributes: nil)
         let contents = """
 {


### PR DESCRIPTION
## Usage
```
sfsymbols --output symbols --format imageset
```
Exports pngs as `imageset` instead of `iconset`