### PR TITLE
add an option for color

### DIFF
--- a/README.md
+++ b/README.md
@@ -66,6 +66,8 @@ There are several options you may specify:
     
     The default value is `svg`.
 
+- `--color`: An RGB or RGBA hex value for the color that the symbol should be exported as. Invalid values default to black. The # character is optional.
+
 ## Disclaimer
 
 This is posted mainly as a proof-of-concept. Use it at your own risk.

--- a/Sources/SFSymbolsCore/ExportOptions.swift
+++ b/Sources/SFSymbolsCore/ExportOptions.swift
@@ -12,11 +12,13 @@ public struct ExportOptions {
     public let verbose: Bool
     public let outputFolder: URL
     public let matchPattern: String
+    public let color: String
     
-    public init(verbose: Bool, outputFolder: URL, matchPattern: String) {
+    public init(verbose: Bool, outputFolder: URL, matchPattern: String, color: String) {
         self.verbose = verbose
         self.outputFolder = outputFolder
         self.matchPattern = matchPattern
+        self.color = color
     }
     
 }

--- a/Sources/SFSymbolsCore/Exporter.swift
+++ b/Sources/SFSymbolsCore/Exporter.swift
@@ -37,8 +37,8 @@ public enum ExportFormat: String, CaseIterable {
 
 public protocol Exporter {
     func exportGlyphs(in font: Font, using options: ExportOptions) throws
-    func exportGlyph(_ glyph: Glyph, in font: Font, to folder: URL) throws
-    func data(for glyph: Glyph, in font: Font) -> Data
+    func exportGlyph(_ glyph: Glyph, in font: Font, colored hexColor: String, to folder: URL) throws
+    func data(for glyph: Glyph, in font: Font, colored hexColor: String) -> Data
 }
 
 extension Exporter {
@@ -50,7 +50,7 @@ extension Exporter {
         
         for glyph in font.glyphs(matching: options.matchPattern) {
             try autoreleasepool {
-                try exportGlyph(glyph, in: font, to: options.outputFolder)
+                try exportGlyph(glyph, in: font, colored: options.color, to: options.outputFolder)
             }
         }
     }

--- a/Sources/SFSymbolsCore/Exporters/IconsetExporter.swift
+++ b/Sources/SFSymbolsCore/Exporters/IconsetExporter.swift
@@ -28,12 +28,12 @@ public struct IconsetExporter: Exporter {
         
         for glyph in font.glyphs(matching: options.matchPattern) {
             try autoreleasepool {
-                try exportGlyph(glyph, in: font, to: assetFolder)
+                try exportGlyph(glyph, in: font, colored: options.color, to: assetFolder)
             }
         }
     }
     
-    public func exportGlyph(_ glyph: Glyph, in font: Font, to folder: URL) throws {
+    public func exportGlyph(_ glyph: Glyph, in font: Font, colored hexColor: String, to folder: URL) throws {
         let iconset = folder.appendingPathComponent("\(glyph.fullName).iconset")
         try FileManager.default.createDirectory(at: iconset, withIntermediateDirectories: true, attributes: nil)
         let contents = """
@@ -68,13 +68,13 @@ public struct IconsetExporter: Exporter {
         try Data(contents.utf8).write(to: contentsURL)
         
         for scale in 1...3 {
-            let data = png.data(for: glyph, in: font, scale: CGFloat(scale))
+            let data = png.data(for: glyph, in: font, scale: CGFloat(scale), color: hexColor)
             let file = iconset.appendingPathComponent("\(glyph.fullName)@\(scale)x.png")
             try data.write(to: file)
         }
     }
     
-    public func data(for glyph: Glyph, in font: Font) -> Data { fatalError() }
+    public func data(for glyph: Glyph, in font: Font, colored hexColor: String) -> Data { fatalError() }
     
 }
 
@@ -99,12 +99,12 @@ public struct PDFAssetCatalog: Exporter {
         
         for glyph in font.glyphs(matching: options.matchPattern) {
             try autoreleasepool {
-                try exportGlyph(glyph, in: font, to: assetFolder)
+                try exportGlyph(glyph, in: font, colored: options.color, to: assetFolder)
             }
         }
     }
     
-    public func exportGlyph(_ glyph: Glyph, in font: Font, to folder: URL) throws {
+    public func exportGlyph(_ glyph: Glyph, in font: Font, colored hexColor: String, to folder: URL) throws {
         let imageset = folder.appendingPathComponent("\(glyph.fullName).imageset")
         try FileManager.default.createDirectory(at: imageset, withIntermediateDirectories: true, attributes: nil)
         let mirrors = glyph.allowsMirroring ? "" : ",\n      \"language-direction\" : \"left-to-right\""
@@ -129,13 +129,13 @@ public struct PDFAssetCatalog: Exporter {
         let contentsURL = imageset.appendingPathComponent("Contents.json")
         try Data(contents.utf8).write(to: contentsURL)
         
-        let pdfData = data(for: glyph, in: font)
+        let pdfData = data(for: glyph, in: font, colored: hexColor)
         let file = imageset.appendingPathComponent("\(glyph.fullName).pdf")
         try pdfData.write(to: file)
     }
     
-    public func data(for glyph: Glyph, in font: Font) -> Data {
-        return pdf.data(for: glyph, in: font)
+    public func data(for glyph: Glyph, in font: Font, colored hexColor: String) -> Data {
+        return pdf.data(for: glyph, in: font, colored: hexColor)
     }
     
 }

--- a/Sources/SFSymbolsCore/Exporters/PDFExporter.swift
+++ b/Sources/SFSymbolsCore/Exporters/PDFExporter.swift
@@ -9,14 +9,14 @@ import Cocoa
 
 public struct PDFExporter: Exporter {
     
-    public func exportGlyph(_ glyph: Glyph, in font: Font, to folder: URL) throws {
+    public func exportGlyph(_ glyph: Glyph, in font: Font, colored hexColor: String, to folder: URL) throws {
         let name = "\(glyph.fullName).pdf"
         let file = folder.appendingPathComponent(name)
-        let glyphData = data(for: glyph, in: font)
+        let glyphData = data(for: glyph, in: font, colored: hexColor)
         try glyphData.write(to: file)
     }
     
-    public func data(for glyph: Glyph, in font: Font) -> Data {
+    public func data(for glyph: Glyph, in font: Font, colored hexColor: String) -> Data {
         let destination = NSMutableData()
         guard let dataConsumer = CGDataConsumer(data: destination as CFMutableData) else { return Data() }
         
@@ -30,7 +30,7 @@ public struct PDFExporter: Exporter {
         pdf.setShouldAntialias(true)
         pdf.addPath(glyph.cgPath)
 
-        pdf.setFillColor(NSColor.black.cgColor)
+        pdf.setFillColor(NSColor(hexString: hexColor).cgColor)
         pdf.fillPath()
         pdf.endPDFPage()
         pdf.closePDF()

--- a/Sources/SFSymbolsCore/Exporters/PNGExporter.swift
+++ b/Sources/SFSymbolsCore/Exporters/PNGExporter.swift
@@ -9,14 +9,14 @@ import Cocoa
 
 public struct PNGExporter: Exporter {
     
-    public func exportGlyph(_ glyph: Glyph, in font: Font, to folder: URL) throws {
+    public func exportGlyph(_ glyph: Glyph, in font: Font, colored hexColor: String, to folder: URL) throws {
         let name = "\(glyph.fullName).png"
         let file = folder.appendingPathComponent(name)
-        let glyphData = data(for: glyph, in: font)
+        let glyphData = data(for: glyph, in: font, colored: hexColor)
         try glyphData.write(to: file)
     }
     
-    public func data(for glyph: Glyph, in font: Font, scale: CGFloat) -> Data {
+    public func data(for glyph: Glyph, in font: Font, scale: CGFloat, color: String) -> Data {
         var size = glyph.boundingBox.size
         size.width *= scale
         size.height *= scale
@@ -27,7 +27,7 @@ public struct PNGExporter: Exporter {
             context.setShouldAntialias(true)
             context.addPath(glyph.cgPath)
 
-            context.setFillColor(NSColor.black.cgColor)
+            context.setFillColor(NSColor(hexString: color).cgColor)
             context.fillPath()
             return true
         })
@@ -35,8 +35,8 @@ public struct PNGExporter: Exporter {
         return image.pngData
     }
     
-    public func data(for glyph: Glyph, in font: Font) -> Data {
-        return data(for: glyph, in: font, scale: 1.0)
+    public func data(for glyph: Glyph, in font: Font, colored hexColor: String) -> Data {
+        return data(for: glyph, in: font, scale: 1.0, color: hexColor)
     }
     
 }

--- a/Sources/SFSymbolsCore/Exporters/iOSExporter.swift
+++ b/Sources/SFSymbolsCore/Exporters/iOSExporter.swift
@@ -13,14 +13,14 @@ public struct iOSSwiftExporter: Exporter {
         return "CGPoint(x: \(point.x), y: \(point.y))"
     }
     
-    public func exportGlyph(_ glyph: Glyph, in font: Font, to folder: URL) throws {
+    public func exportGlyph(_ glyph: Glyph, in font: Font, colored hexColor: String, to folder: URL) throws {
         let name = "\(glyph.fullName).swift"
         let file = folder.appendingPathComponent(name)
-        let glyphData = data(for: glyph, in: font)
+        let glyphData = data(for: glyph, in: font, colored: hexColor)
         try glyphData.write(to: file)
     }
     
-    public func data(for glyph: Glyph, in font: Font) -> Data {
+    public func data(for glyph: Glyph, in font: Font, colored hexColor: String) -> Data {
         var restriction = ""
         if let r = glyph.restrictionNote {
             restriction = "\n    // \(r)"
@@ -66,10 +66,10 @@ public struct iOSObjCExporter: Exporter {
         return "CGPoint(x: \(point.x), y: \(point.y))"
     }
     
-    public func exportGlyph(_ glyph: Glyph, in font: Font, to folder: URL) throws {
+    public func exportGlyph(_ glyph: Glyph, in font: Font, colored hexColor: String, to folder: URL) throws {
         let name = "UIBezierPath+\(glyph.fullName).m"
         let file = folder.appendingPathComponent(name)
-        let glyphData = data(for: glyph, in: font)
+        let glyphData = data(for: glyph, in: font, colored: hexColor)
         try glyphData.write(to: file)
         
         var restriction = ""
@@ -90,7 +90,7 @@ public struct iOSObjCExporter: Exporter {
         try Data(header.utf8).write(to: headerFile)
     }
     
-    public func data(for glyph: Glyph, in font: Font) -> Data {
+    public func data(for glyph: Glyph, in font: Font, colored hexColor: String) -> Data {
         let header = """
         #import "UIBezierPath+\(glyph.fullName).h"
 

--- a/Sources/SFSymbolsCore/Exporters/macOSExporter.swift
+++ b/Sources/SFSymbolsCore/Exporters/macOSExporter.swift
@@ -9,10 +9,10 @@ import Cocoa
 
 public struct macOSSwiftExporter: Exporter {
     
-    public func exportGlyph(_ glyph: Glyph, in font: Font, to folder: URL) throws {
+    public func exportGlyph(_ glyph: Glyph, in font: Font, colored hexColor: String, to folder: URL) throws {
         let name = "\(glyph.fullName).swift"
         let file = folder.appendingPathComponent(name)
-        let glyphData = data(for: glyph, in: font)
+        let glyphData = data(for: glyph, in: font, colored: hexColor)
         try glyphData.write(to: file)
     }
     
@@ -20,7 +20,7 @@ public struct macOSSwiftExporter: Exporter {
         return "CGPoint(x: \(point.x), y: \(point.y))"
     }
     
-    public func data(for glyph: Glyph, in font: Font) -> Data {
+    public func data(for glyph: Glyph, in font: Font, colored hexColor: String) -> Data {
         var restriction = ""
         if let r = glyph.restrictionNote {
             restriction = "\n    // \(r)"
@@ -67,10 +67,10 @@ public struct macOSSwiftExporter: Exporter {
 
 public struct macOSObjCExporter: Exporter {
     
-    public func exportGlyph(_ glyph: Glyph, in font: Font, to folder: URL) throws {
+    public func exportGlyph(_ glyph: Glyph, in font: Font, colored hexColor: String, to folder: URL) throws {
         let name = "NSBezierPath+\(glyph.fullName).m"
         let file = folder.appendingPathComponent(name)
-        let glyphData = data(for: glyph, in: font)
+        let glyphData = data(for: glyph, in: font, colored: hexColor)
         try glyphData.write(to: file)
         
         var restriction = ""
@@ -95,7 +95,7 @@ public struct macOSObjCExporter: Exporter {
         return "CGPoint(x: \(point.x), y: \(point.y))"
     }
     
-    public func data(for glyph: Glyph, in font: Font) -> Data {
+    public func data(for glyph: Glyph, in font: Font, colored hexColor: String) -> Data {
         let header = """
         #import "NSBezierPath+\(glyph.fullName).h"
 

--- a/Sources/SFSymbolsCore/NSColorExtenstions.swift
+++ b/Sources/SFSymbolsCore/NSColorExtenstions.swift
@@ -1,0 +1,57 @@
+//
+//  NSColorExtensions.swift
+//  
+//
+//  Created by Steven Vlaminck on 7/8/20.
+//
+
+import Cocoa
+
+extension NSColor {
+  
+  public convenience init(hexString hex: String) {
+    let r, g, b, a: CGFloat
+    
+    var hexColor: String = hex
+    
+    if hex.hasPrefix("#") {
+      // strip the first character so we only deal with hex values
+      let start = hex.index(hex.startIndex, offsetBy: 1)
+      hexColor = String(hex[start...])
+    }
+    
+    if hexColor.count == 6 {
+      // no alpha was sent. default to 100% alpha
+      hexColor = "\(hexColor)FF"
+    }
+    
+    if hexColor.count == 8 {
+      let scanner = Scanner(string: hexColor)
+      var hexNumber: UInt64 = 0
+      
+      if scanner.scanHexInt64(&hexNumber) {
+        r = CGFloat((hexNumber & 0xff000000) >> 24) / 255
+        g = CGFloat((hexNumber & 0x00ff0000) >> 16) / 255
+        b = CGFloat((hexNumber & 0x0000ff00) >> 8) / 255
+        a = CGFloat(hexNumber & 0x000000ff) / 255
+        
+        self.init(red: r, green: g, blue: b, alpha: a)
+        return
+      }
+    }
+    
+    // we failed to parse this color. return black
+    self.init(red: 0, green: 0, blue: 0, alpha: 1)
+  }
+  
+  func toHexString() -> String {
+    var r:CGFloat = 0
+    var g:CGFloat = 0
+    var b:CGFloat = 0
+    var a:CGFloat = 0
+    getRed(&r, green: &g, blue: &b, alpha: &a)
+    let rgba: Int = (Int)(r * 255) << 24 | (Int)(g * 255) << 16 | (Int)(b * 255) << 8 | (Int)(a * 255) << 0
+    return String(format:"#%08x", rgba).uppercased()
+  }
+  
+}

--- a/Sources/sfsymbols/Parser.swift
+++ b/Sources/sfsymbols/Parser.swift
@@ -67,12 +67,17 @@ struct SFSymbols: ParsableCommand {
 
     @Flag(help: "Log verbose information about how exporting is proceeding")
     var verbose: Bool
+  
+    @Option(default: "000000",
+            help: "An RGB or RGBA hex value for the color that the symbol should be exported as. Invalid values default to black. The # character is optional.")
+    var color: String
 
     func constructConfiguration() throws -> Configuration {
         let exportOptions = ExportOptions(
             verbose: verbose,
             outputFolder: URL(fileURLWithPath: output),
-            matchPattern: symbolName)
+            matchPattern: symbolName,
+            color: color)
         let fontDescriptor = Font.Descriptor(
             family: fontFamily,
             variant: fontVariant,


### PR DESCRIPTION
### What
This allows the color to be configured by passing a hex value via `--color`
* Hex values must be either 6 or 8 characters long (not including the `#` character)
* The `#` character is optional
* The hex format is RGB or RGBA

### Valid Examples
```
sfsymbols --output symbols --format png --color "#00dd1133"
sfsymbols --output symbols --format png --color 00dd1133
sfsymbols --output symbols --format png --color "#aa1122"
sfsymbols --output symbols --format png --color AA1122
```

### Limitations
Exporters that use bezier paths aren't supported because a color wasn't specified in those files. This implementation simply replaces the hard-coded `black` values with a configurable option. I can spend time making sure the other exporters make use of the color as well, but since they export code, I feel like it would be easier to update the exported code afterward.

### Other Considerations
This could be updated to use named colors as well as hex values. In which case, I'd want to change the options to something like `--hexColor` and `--namedColor`.
