### PR TITLE
Make printed errors show defined messages

### DIFF
--- a/Sources/sfsymbols/main.swift
+++ b/Sources/sfsymbols/main.swift
@@ -9,7 +9,7 @@ extension SFSymbols {
             let configuration = try constructConfiguration()
             try configuration.run()
         } catch {
-            print(error.localizedDescription)
+            print("\(error)")
         }
     }
 }


### PR DESCRIPTION
Printing the error's localized description (before):
```
The operation couldn’t be completed. (sfsymbols.ArgumentParserError error 5.)
Program ended with exit code: 0
```

Printing the error object itself (after):
```
fontLocationString("Unable to locate suitable SF Symbols font")
Program ended with exit code: 0
```