### PR TITLE
Update arg parsing code and enum definitions

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -11,8 +11,7 @@ let package = Package(
     ],
     dependencies: [
         // Dependencies declare other packages that this package depends on.
-        // .package(url: /* package url */, from: "1.0.0"),
-        .package(url: "https://github.com/apple/swift-argument-parser", from: "0.0.2")
+        .package(url: "https://github.com/apple/swift-argument-parser", from: "0.3.0")
     ],
     targets: [
         // Targets are the basic building blocks of a package. A target can define a module or a test suite.

--- a/Sources/SFSymbolsCore/Exporter.swift
+++ b/Sources/SFSymbolsCore/Exporter.swift
@@ -10,15 +10,15 @@ import AppKit
 
 public enum ExportFormat: String, CaseIterable {
     
-    case svg = "svg"
-    case iosSwift = "ios-swift"
-    case iosObjC = "ios-objc"
-    case macosSwift = "macos-swift"
-    case macosObjC = "macos-objc"
-    case png = "png"
-    case pdf = "pdf"
-    case iconset = "iconset"
-    case iconsetPDF = "iconset-pdf"
+    case svg
+    case iosSwift
+    case iosObjC
+    case macosSwift
+    case macosObjC
+    case png
+    case pdf
+    case iconset
+    case iconsetPDF
     
     public var exporter: Exporter {
         switch self {

--- a/Sources/SFSymbolsCore/Font.swift
+++ b/Sources/SFSymbolsCore/Font.swift
@@ -28,14 +28,14 @@ public struct Font {
     public typealias Weight = NSFont.Weight
     
     public enum Family: String, CaseIterable {
-        case pro = "Pro"
-        case compact = "Compact"
+        case Pro
+        case Compact
     }
     
     public enum Variant: String, CaseIterable {
-        case display = "Display"
-        case rounded = "Rounded"
-        case text = "Text"
+        case Display
+        case Rounded
+        case Text
     }
     
     public struct Descriptor {

--- a/Sources/sfsymbols/Parser.swift
+++ b/Sources/sfsymbols/Parser.swift
@@ -29,44 +29,32 @@ struct SFSymbols: ParsableCommand {
     @Option(help: "A path to the SFSymbols ttf file. If omitted, the font will be located in a copy of SF Symbols.app")
     var fontFile: String?
 
-    @Option(default: Font.Family(rawValue: "Pro"),
-            help: "The family of SF font to use",
-            transform: toFontFamily)
-    var fontFamily: Font.Family
+    @Option(help: "The family of SF font to use",transform: toFontFamily)
+    var fontFamily: Font.Family = .Pro
 
-    @Option(default: Font.Variant(rawValue: "Display"),
-            help: "The family of SF font to use",
-            transform: toFontVariant)
-    var fontVariant: Font.Variant
+    @Option(help: "The family of SF font to use",transform: toFontVariant)
+    var fontVariant: Font.Variant = .Display
 
-    @Option(default: Font.Weight.regular,
-            help: "The weight of the SFSymbols font to use",
-            transform: toFontWeight)
-    var fontWeight: Font.Weight
+    @Option(help: "The weight of the SFSymbols font to use",transform: toFontWeight)
+    var fontWeight: Font.Weight = Font.Weight.regular
 
-    @Option(default: 44, help: "The size of symbol to use.")
-    var fontSize: Int
+    @Option(help: "The size of symbol to use.")
+    var fontSize: Int = 44
 
-    @Option(default: Glyph.Size(rawValue: "medium"),
-            help: "The size of symbol to use",
-            transform: toGlyphSize)
-    var symbolSize: Glyph.Size
+    @Option(help: "The size of symbol to use",transform: toGlyphSize)
+    var symbolSize: Glyph.Size = .medium
 
-    @Option(default: "*",
-            help: "A pattern to limit which symbols are exported. Example: '*.fill' or '*cloud*'")
-    var symbolName: String
+    @Option(help: "A pattern to limit which symbols are exported. Example: '*.fill' or '*cloud*'")
+    var symbolName: String = "*"
 
-    @Option(default: ExportFormat(rawValue: "svg"),
-            help: "The formatter to use when exporting",
-            transform: toExportFormat)
-    var format: ExportFormat
+    @Option(help: "The formatter to use when exporting",transform: toExportFormat)
+    var format: ExportFormat = .svg
 
-    @Option(default: ".",
-            help: "A path to the folder where symbols will be exported.")
-    var output: String
+    @Option(help: "A path to the folder where symbols will be exported.")
+    var output: String = "."
 
     @Flag(help: "Log verbose information about how exporting is proceeding")
-    var verbose: Bool
+	var verbose: Bool = false
 
     func constructConfiguration() throws -> Configuration {
         let exportOptions = ExportOptions(


### PR DESCRIPTION
This project is likely at a dead-end unless we figure out how to parse the 2.x SF Symbols font files. But I though I would update some of the less important code in case it can move forward.

    - Update the @Option to no longer use "default:".
    - Assign default values directly to the variable.
    - Remove string literals from enum definitions.
    - Use more modern syntax to assign enum values to variables: var fontFamily: Font.Family = .Pro
    - Bump min version number for swift-argument-parser package.